### PR TITLE
Wip hdcs datastore transaction

### DIFF
--- a/src/common/AioCompletionImp.h
+++ b/src/common/AioCompletionImp.h
@@ -23,8 +23,8 @@ public:
   void complete(ssize_t r) {
     if (defined) {
       if (--shared_count == 0) {
-        cond.notify_all();
         Callback(r);
+        cond.notify_all();
         if (delete_when_complete) delete this;
       }
     } else {
@@ -35,7 +35,9 @@ public:
   void wait_for_complete() {
     if (shared_count > 0) {
       std::unique_lock<std::mutex> l(cond_lock);
-      cond.wait(l);
+      while( shared_count > 0 ) {
+        cond.wait_for(l, std::chrono::milliseconds(50));
+      }
     }
   };
   void set_reserved_ptr(void* ptr) {

--- a/src/core/BlockOp.h
+++ b/src/core/BlockOp.h
@@ -542,6 +542,29 @@ public:
 private:
   const std::shared_ptr<AioCompletion> &comp;
 };
+
+class ExecuteDataStoreRequest : public BlockOp{
+public:
+  ExecuteDataStoreRequest(uint64_t entry_id, char* data,
+                     store::DataStore* data_store,
+                     Block* block,
+                     BlockRequest* block_request,
+                     BlockOp* block_op) :
+                     BlockOp(block, block_request, block_op),
+                     entry_id(entry_id), data(data), data_store(data_store) {
+  }
+  void send(BlockOp* prev_block_op = nullptr) {
+    if (prev_block_op) {
+      delete prev_block_op;
+    }
+    block_request->data_store_req->prepare_request(data_store, entry_id, data);
+    complete(0);
+  }
+private:
+  uint64_t entry_id;
+  char* data;
+  store::DataStore* data_store;
+};
 } //core
 
 } //hdcs

--- a/src/core/BlockRequest.h
+++ b/src/core/BlockRequest.h
@@ -4,6 +4,7 @@
 #include "common/Log.h"
 #include "common/Request.h"
 #include "core/BlockMap.h"
+#include "store/DataStoreRequest.h"
 
 namespace hdcs {
 
@@ -13,10 +14,10 @@ class BlockRequest {
 public:
   BlockRequest(char* data_ptr, uint64_t offset,
                uint64_t size, std::shared_ptr<Request> req,
-               Block* block, std::shared_ptr<AioCompletion> comp) :
+               Block* block, std::shared_ptr<store::DataStoreRequest> data_store_req) :
                data_ptr(data_ptr), offset(offset), 
                size(size), req(req), block(block),
-               comp(comp), should_delete(false) {
+               data_store_req(data_store_req), should_delete(false) {
     if (req != nullptr) {
       req->add_request();  
     }           
@@ -34,7 +35,7 @@ public:
   char* data_ptr;
   bool should_delete;
   std::shared_ptr<Request> req;
-  std::shared_ptr<AioCompletion> comp;
+  std::shared_ptr<store::DataStoreRequest> data_store_req;
 };
 typedef std::list<BlockRequest> BlockRequestList;
 

--- a/src/store/DataStoreRequest.h
+++ b/src/store/DataStoreRequest.h
@@ -1,0 +1,133 @@
+// Copyright [2017] <Intel>
+#ifndef HDCS_DATA_STORE_REQUEST_H
+#define HDCS_DATA_STORE_REQUEST_H
+#include <stdint.h>
+#include <map>
+#include <mutex>
+#include "common/AioCompletionImp.h"
+#include "store/DataStore.h"
+#include "common/HDCS_REQUEST_CTX.h"
+
+namespace hdcs {
+namespace store {
+typedef std::map<std::string, void*> hdcs_replica_nodes_t;
+typedef std::map<uint64_t, std::pair<uint64_t, char*> > data_store_request_chain_t; 
+//typedef void DataStore;
+
+  class DataStoreRequest {
+  public:
+    DataStoreRequest(uint8_t shared_count, uint64_t block_size,
+                     AioCompletion* replica_comp,
+                     hdcs_replica_nodes_t* connection_v):
+      shared_count(shared_count), data_store(nullptr), replica_comp(replica_comp),
+      block_size(block_size), connection_v(connection_v){
+        //create comp for prepare_data_store_req.
+        data_store_comp = std::make_shared<AioCompletionImp>([&](ssize_t r){
+          submit_request();
+        }, shared_count, false);
+    }
+
+    ~DataStoreRequest() {
+    }
+
+    int prepare_request(DataStore* data_store_tmp, uint64_t block_id, char* data) {
+      data_store_mutex.lock();
+      data_store = data_store_tmp;
+
+      //printf("offset: %lu, data: %p\n", block_id * block_size, data);
+      data_store_request_chain_t::iterator cur_it;
+      bool inserted = false;
+      uint64_t block_size_tmp = block_size;
+      uint8_t step = block_size_tmp / block_size;
+      for (data_store_request_chain_t::iterator it = data_store_req_chain.begin(); 
+          it != data_store_req_chain.end();) {
+        cur_it = it++;
+
+        // merge to the block before to this one
+          if (cur_it->second.second + cur_it->second.first == data) {
+            cur_it->second.first += block_size_tmp;
+            block_id = cur_it->first;
+            block_size_tmp = cur_it->second.first;
+            data = cur_it->second.second;
+            inserted = true;
+          }
+
+        // merge to the block next to this one
+          if (data + block_size_tmp == cur_it->second.second) {
+            uint64_t tmp_size = block_size_tmp + cur_it->second.first;
+            //insert new one
+            data_store_req_chain[block_id] = std::make_pair(tmp_size, data);
+ 
+            //remove original one
+            data_store_req_chain.erase(cur_it);
+            block_size_tmp = tmp_size;
+            inserted = true;
+          }
+
+      }// end for
+      if (!inserted) {
+        data_store_req_chain[block_id] = std::make_pair(block_size_tmp, data);
+      }
+
+      data_store_mutex.unlock();
+      data_store_comp->complete(0);
+      data_store_comp->wait_for_complete();
+    }
+
+    int submit_request() {
+      void* io_ctx;
+      int ret = 0;
+      uint64_t offset;
+      uint64_t length;
+      char* data_ptr;
+      //char print_buffer[256];
+      //int print_buffer_size = 0;
+
+      //sprintf(print_buffer, "New batch\n");
+      for (data_store_request_chain_t::iterator it = data_store_req_chain.begin(); 
+          it != data_store_req_chain.end(); it++) {
+
+        //todo: different at cache mode.
+        offset = it->first * block_size;
+        length = it->second.first;
+        data_ptr = it->second.second;
+
+        //submit request to replica
+        for (const auto& replica_node : *connection_v) {
+          io_ctx = replica_node.second;
+          hdcs::HDCS_REQUEST_CTX msg_content(HDCS_WRITE, ((hdcs_ioctx_t*)io_ctx)->hdcs_inst,
+                                             replica_comp, offset, length, data_ptr);
+          ((hdcs_ioctx_t*)io_ctx)->conn->aio_communicate(std::move(std::string(msg_content.data(), msg_content.size())));
+        }
+
+        //submit request to local
+        //print_buffer_size = strlen(print_buffer);
+        //sprintf(&print_buffer[print_buffer_size], "  DataStore %p write %p to %lu(%lu)\n", data_store, data_ptr, offset, length);
+        ret = data_store->write(data_ptr, offset, length);
+        if (ret < 0) {
+          log_err("data_store->write failed\n");
+          return ret;
+        }
+      }
+      //printf("%s", print_buffer);
+      return ret;
+    }
+
+  private:
+    //DataStore
+    data_store_request_chain_t data_store_req_chain;
+
+    std::mutex data_store_mutex;
+    std::shared_ptr<AioCompletion> data_store_comp;
+    uint8_t shared_count;
+    DataStore* data_store;
+    IO_TYPE io_type;
+    uint64_t block_size;
+    hdcs_replica_nodes_t* connection_v;
+    AioCompletion* replica_comp;
+
+  };
+}// store
+}// hdcs
+
+#endif

--- a/src/store/SimpleStore/SimpleBlockStore.cpp
+++ b/src/store/SimpleStore/SimpleBlockStore.cpp
@@ -127,5 +127,27 @@ int SimpleBlockStore::block_meta_update(uint64_t block_id, BLOCK_STATUS_TYPE sta
 BLOCK_STATUS_TYPE SimpleBlockStore::get_block_meta(uint64_t block_id) {
   return meta_store_mmap[block_id];
 }
+
+int SimpleBlockStore::write(char* data, uint64_t offset, uint64_t size) {
+  /* skip disk access */
+  //return 0;
+  int ret = ::pwrite(data_store_fd, data, size, offset); 
+  if (ret < 0) {
+    log_err("[ERROR] SimpleBlockStore::write, unable to write offset %lu, size %lu, error: %s ", offset, size, std::strerror(ret));
+    return ret;
+  }
+  return ret;
+}
+
+int SimpleBlockStore::read(char* data, uint64_t offset, uint64_t size) {
+  /* skip disk access */
+  //return 0;
+  int ret = ::pread(data_store_fd, data, size, offset); 
+  if (ret < 0) {
+    log_err("[ERROR] SimpleBlockStore::read, unable to read offset %lu, size %lu, error: %s ", offset, size, std::strerror(ret));
+    return ret;
+  }
+}
+
 }// store
 }// hdcs

--- a/src/store/SimpleStore/SimpleBlockStore.h
+++ b/src/store/SimpleStore/SimpleBlockStore.h
@@ -13,8 +13,8 @@ namespace store {
     SimpleBlockStore(std::string store_path, uint64_t total_size, uint64_t store_size, uint64_t block_size);
     ~SimpleBlockStore();
 
-    int write(char* data, uint64_t offset, uint64_t size){}
-    int read(char* data, uint64_t offset, uint64_t size){}
+    int write(char* data, uint64_t offset, uint64_t size);
+    int read(char* data, uint64_t offset, uint64_t size);
     int aio_write(char* data, uint64_t offset, uint64_t size, AioCompletion* on_finish){}
     int aio_read(char* data, uint64_t offset, uint64_t size, AioCompletion* on_finish){}
     int block_write(uint64_t block_id, char* data);


### PR DESCRIPTION
Add data store request support, aiming to use this request to merge back big requests like 16K and submit to datastore in same transaction.

initial test shows promising results, using my dev cluster with S3700, 16K randwrite test, it gets 213MB/s and 99.99lat decreased by 65% compared with wo/ this feature.  and this feature helps to make transactional support easier.

iops         | bw(MB/s) | latency(msec) | 95%lat(msec) | 99%lat(msec) | 99.99thlat(msec)
13640      | 213           | 2.26               | 3.39                 | 4.51               | 8.91

