### PR TITLE
Networking: fix communicate API

### DIFF
--- a/src/Network/asio_common/asio_messenger.h
+++ b/src/Network/asio_common/asio_messenger.h
@@ -318,14 +318,15 @@ public:
                                     assert(0);
                                 }
                                 aio_receive();
-				//c_process_msg(callback_arg, std::move(std::string(data_buffer, content_size)));
+
+                                //trigger request handler first
+				c_process_msg(callback_arg, std::move(std::string(data_buffer, content_size)));
                                 if(pending_msg_map.size()!=0){
                                     // lock? TODO
                                     pending_msg_map[sequence_id]->Done();
                                     delete pending_msg_map[sequence_id];
                                     pending_msg_map.erase(sequence_id);
                                 }
-				c_process_msg(callback_arg, std::move(std::string(data_buffer, content_size)));
 				//thread_worker.post(boost::bind(c_process_msg, callback_arg, std::move(std::string(data_buffer,content_size))));
                             }else{ 
                                 // TODO error handing 


### PR DESCRIPTION
request handler should be triggered before wake up the receiver

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>